### PR TITLE
[minor] implemented fmt.Formatter interface

### DIFF
--- a/currency.go
+++ b/currency.go
@@ -3,6 +3,8 @@ package currency
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"math"
 	"regexp"
 	"strconv"
@@ -217,6 +219,38 @@ func (c *Currency) String(prefixSymbol bool) string {
 	}
 
 	return str
+}
+
+func (c *Currency) Format(s fmt.State, verb rune) {
+	switch verb {
+	// 's' verb would produce the full currency string along with its symbol. equivalent to c.String(true)
+	case 's':
+		{
+			_, _ = io.WriteString(s, c.String(true))
+		}
+	// 'd' verb would produce the main integer part of the currency, without the symbol
+	case 'd':
+		{
+			main := strconv.Itoa(c.Main)
+			_, _ = io.WriteString(s, main)
+		}
+	// 'm' verb would produce the fractional integer part of the currency, without the symbol
+	case 'm':
+		{
+			main := strconv.Itoa(c.Fractional)
+			_, _ = io.WriteString(s, main)
+		}
+	// 'f' verb would produce the full currency string without its symbol. equivalent to c.String(false)
+	case 'f':
+		{
+			_, _ = io.WriteString(s, c.String(false))
+		}
+	// 'y' verb would produce the currency symbol alone
+	case 'y':
+		{
+			_, _ = io.WriteString(s, c.Symbol)
+		}
+	}
 }
 
 // round rounds off the float value to the configured precision and returns an integer.

--- a/currency_test.go
+++ b/currency_test.go
@@ -1,6 +1,7 @@
 package currency
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -235,6 +236,42 @@ func TestParseFloat64(t *testing.T) {
 		if ft != nT.out.totalfractional {
 			t.Log("Expected:", nT.out.totalfractional, "got:", ft)
 			t.Fail()
+		}
+	}
+}
+
+func TestFormat(t *testing.T) {
+	c, _ := New(12, 75, "INR", "₹", "paise", 100)
+	list := []struct {
+		Verb     string
+		Expected string
+	}{
+		{
+			Verb:     "s",
+			Expected: "₹12.75",
+		},
+		{
+			Verb:     "d",
+			Expected: "12",
+		},
+		{
+			Verb:     "m",
+			Expected: "75",
+		},
+		{
+			Verb:     "f",
+			Expected: "12.75",
+		},
+		{
+			Verb:     "y",
+			Expected: "₹",
+		},
+	}
+	for _, l := range list {
+		formatstr := "%" + l.Verb
+		str := fmt.Sprintf(formatstr, c)
+		if str != l.Expected {
+			t.Errorf("Format string: %s, Expected '%s', got '%s'", formatstr, l.Expected, str)
 		}
 	}
 }


### PR DESCRIPTION
- 's' verb would produce the full currency string along with its symbol. equivalent to c.String(true)
- 'd' verb would produce the main integer part of the currency, without the symbol
- 'm' verb would produce the fractional integer part of the currency, without the symbol
- 'f' verb would produce the full currency string without its symbol. equivalent to c.String(false)
- 'y' verb would produce the currency symbol alone